### PR TITLE
Show CppYCM pannel only if there are errors.

### DIFF
--- a/commands/highlight_problems.py
+++ b/commands/highlight_problems.py
@@ -84,8 +84,9 @@ class CppycmHighlightProblemsCommand(sublime_plugin.WindowCommand):
             line_regions[(region.a, region.b)] = message
 
         self.output_panel.set_read_only(True)
-        self.window.run_command(
-            'show_panel', {'panel': self.output_panel_name})
+        if problems:
+            self.window.run_command(
+                'show_panel', {'panel': self.output_panel_name})
         # self.view_cache[view_id] = view_cache
         style = (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE |
                  sublime.DRAW_SQUIGGLY_UNDERLINE)


### PR DESCRIPTION
It is a bit annoying when empty CppYCM panel pops after each save of the file. I think, It would be better if panel will be shown only if there are errors in the code. 
